### PR TITLE
修改docker-compose.yaml文件中，rocketmq配置文件容器内挂载位置

### DIFF
--- a/doc/中间件docker-compse一键安装/docker-compose.yaml
+++ b/doc/中间件docker-compse一键安装/docker-compose.yaml
@@ -139,10 +139,10 @@ services:
     volumes:
       - ./rocketmq/broker/logs:/home/rocketmq/logs
       - ./rocketmq/broker/store:/home/rocketmq/store
-      - ./rocketmq/broker/conf/broker.conf:/etc/rocketmq/broker.conf
+      - ./rocketmq/broker/conf/broker.conf:/home/rocketmq/rocketmq-4.9.4/conf/broker.conf
     environment:
       JAVA_OPT_EXT: "-Duser.home=/home/rocketmq -Xms512M -Xmx512M -Xmn128M -XX:-AssumeMP"
-    command: ["sh","mqbroker","-c","/etc/rocketmq/broker.conf","-n","mall4cloud-rocketmq-namesrv:9876","autoCreateTopicEnable=true"]
+    command: ["sh","mqbroker","-c","/home/rocketmq/rocketmq-4.9.4/conf/broker.conf","-n","mall4cloud-rocketmq-namesrv:9876","autoCreateTopicEnable=true"]
     depends_on:
       - mall4cloud-rocketmq-namesrv
     networks:


### PR DESCRIPTION
rocketmq的broker.conf默认文件位置有误